### PR TITLE
add support for process with numprocs > 1

### DIFF
--- a/app/views/actions.twig
+++ b/app/views/actions.twig
@@ -1,3 +1,3 @@
-<a href="/start/{{ instance }}/{{ process }}" title="Start" data-toggle="tooltip"><span class="glyphicon glyphicon-play text-success"></span></a>
-<a href="/restart/{{ instance }}/{{ process }}" title="Restart" data-toggle="tooltip"><span class="glyphicon glyphicon-refresh"></span></a>
-<a href="/stop/{{ instance }}/{{ process }}" title="Stop" data-toggle="tooltip"><span class="glyphicon glyphicon-stop text-danger"></span></a>
+<a href="/start/{{ instance }}/{{ group }}:{{ process }}" title="Start" data-toggle="tooltip"><span class="glyphicon glyphicon-play text-success"></span></a>
+<a href="/restart/{{ instance }}/{{ group }}:{{ process }}" title="Restart" data-toggle="tooltip"><span class="glyphicon glyphicon-refresh"></span></a>
+<a href="/stop/{{ instance }}/{{ group }}:{{ process }}" title="Stop" data-toggle="tooltip"><span class="glyphicon glyphicon-stop text-danger"></span></a>

--- a/app/views/layout/grid.twig
+++ b/app/views/layout/grid.twig
@@ -21,7 +21,7 @@
                                     <td>{{ process.name }}</td>
                                     <td><span class="label label-{{ process.statename|state }}">{{ process.statename }}</span></td>
                                     <td>{{ process|state_ago }}</td>
-                                    <td>{% include 'actions.twig' with {'instance': name, 'process': process.name} only %}</td>
+                                    <td>{% include 'actions.twig' with {'instance': name, 'process': process.name, 'group': process.group} only %}</td>
                                 </tr>
                             {% else %}
                                 <tr><td><i>No processes</i></td></tr>


### PR DESCRIPTION
When a process is configured with numprocs > 1, its name is equal to:

group:name

"group" is missing from url to control instances..

If a process has numprocs = 1, you can also control it with group:name

So my patch is very simple!
